### PR TITLE
Winners List - PCN Kindness Challenge 2024

### DIFF
--- a/_whats-happening/Events.md
+++ b/_whats-happening/Events.md
@@ -4,11 +4,15 @@ permalink: /do-more/events/
 description: ""
 variant: tiptap
 ---
-<h2>PCN Kindness Campaign 2024</h2>
-<h5>17 May to 31 June 2024</h5>
+<h2>PCN Kindness Challenge 2024</h2>
+<h5>17 May to 23 June 2024</h5>
 <div class="isomer-image-wrapper">
 <img style="width: 100%" height="auto" width="100%" alt="PCN Kindness Challenge 2024" src="/images/PCN_Kindness_Challenge_2024.png">
 </div>
+<p><strong>The PCN Kindness Challenge 2024 has ended! </strong>
+<br><strong>Thank you for your support!</strong>
+</p>
+<hr>
 <p>Giving way to pedestrians along the path? Helping an elderly at the intersection?
 Kindness goes a long way on our trails and on the Park Connector Network
 (PCN)!</p>
@@ -41,6 +45,115 @@ remember to stay gracious and share the path together!</p>
 </p>
 <p><strong>#PCNKindness #NParksBuzz #ParkConnectorNetwork</strong>
 </p>
+<p></p>
+<h4><strong>Winners</strong></h4>
+<p>The event has concluded on 23 June 2024. Congratulations to the winners
+below!</p>
+<p><strong><u>Top 3</u></strong>
+</p>
+<ol data-tight="true" class="tight">
+<li>
+<p>Ah Song</p>
+</li>
+<li>
+<p>joyceho</p>
+</li>
+<li>
+<p>UserPH</p>
+</li>
+</ol>
+<p><strong><u>Runner Up</u></strong>
+</p>
+<ol start="4" data-tight="true" class="tight">
+<li>
+<p>BearTan</p>
+</li>
+<li>
+<p>JoelLim</p>
+</li>
+<li>
+<p>yaptatkwong</p>
+</li>
+<li>
+<p>happii</p>
+</li>
+<li>
+<p>kevkbh</p>
+</li>
+<li>
+<p>John_Chew</p>
+</li>
+<li>
+<p>TEEGUATCHING</p>
+</li>
+</ol>
+<p><strong><u>Lucky Draw</u></strong>
+</p>
+<ul data-tight="true" class="tight">
+<li>
+<p>yh chua</p>
+</li>
+<li>
+<p>AKH2017</p>
+</li>
+<li>
+<p>Xukaiwen</p>
+</li>
+<li>
+<p>ciufung</p>
+</li>
+<li>
+<p>chweehong</p>
+</li>
+<li>
+<p>ThinnKat</p>
+</li>
+<li>
+<p>Malaguena</p>
+</li>
+<li>
+<p>clarasio</p>
+</li>
+<li>
+<p>Wyvern8888</p>
+</li>
+<li>
+<p>WalkerTL</p>
+</li>
+<li>
+<p>HengKai</p>
+</li>
+<li>
+<p>Hui Yee</p>
+</li>
+<li>
+<p>nikhilmuraleesadanam</p>
+</li>
+<li>
+<p>SohamManu</p>
+</li>
+<li>
+<p>Laychin</p>
+</li>
+<li>
+<p>gaybee</p>
+</li>
+<li>
+<p>miaomiuemma</p>
+</li>
+<li>
+<p>joshhhh</p>
+</li>
+<li>
+<p>linmjustin</p>
+</li>
+<li>
+<p>ckohingreen</p>
+</li>
+</ul>
+<p></p>
+<p>Congratulations to all who have won in this this year's challenge.
+<br>We will reach out to you via email with details on collection of the prizes.</p>
 <hr>
 <h2>PCN Kindness Campaign 2023</h2>
 <h5>24 June 2023 to 30 July 2023</h5>


### PR DESCRIPTION
Events Page: Added the Winners List in the PCN Kindness Challenge 2024 post. Includes names of Top 3, Runner Up and lucky draw winners.