### PR TITLE
Changed Footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-title: NParks Park Connector Network
+title: National Parks Board
 url: https://pcn.nparks.gov.sg
 favicon: /images/NParks%20Logo.png
 colors:

--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 ---
 layout: homepage
-title: NParks Park Connector Network
+title: National Parks Board
 description: NParks Park Connector Network Website
 image: /images/NParks Logo.png
 permalink: /


### PR DESCRIPTION
Site title adjusted to "National Parks Board" to reflect footer as (c) 2025 National Parks Board. Last updated on (date)